### PR TITLE
Introducing the services object

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -4,9 +4,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@generated/photon": "0.0.0-generated",
-    "@hammerframework/api": "^0.0.1-alpha.13.2",
-    "graphql-iso-date": "^3.6.1",
-    "nexus": "v0.12.0-beta.14",
+    "@hammerframework/api": "^0.0.1-alpha.14",
     "dotenv": "^8.2.0"
   },
   "devDependencies": {

--- a/api/src/graphql/posts.sdl.js
+++ b/api/src/graphql/posts.sdl.js
@@ -1,4 +1,6 @@
 import { gql } from '@hammerframework/api'
+
+import { services } from 'src/services'
 import Posts from 'src/services/posts'
 
 export const schema = gql`
@@ -45,48 +47,17 @@ export const schema = gql`
 
 export const resolvers = {
   Query: {
-    allPosts: (_root, args) => {
-      return Posts.allPosts(args)
-    },
-
-    findPostById: (_root, args) => {
-      return Posts.findPostById(args)
-    },
-
-    findPostBySlug: (_root, args) => {
-      return Posts.findPostBySlug(args)
-    },
-
-    findPostsByTag: (_root, args) => {
-      return Posts.findPostsByTag(args)
-    },
-
-    searchPosts: (_root, args) => {
-      return Posts.searchPosts(args)
-    },
-
-    postsCount: (_root, args) => {
-      const count = Posts.postsCount(args)
-      console.info(count)
-      return count
-    },
+    allPosts: services.posts.allPosts,
+    findPostById: services.posts.findPostById,
+    findPostBySlug: services.posts.findPostBySlug,
+    findPostsByTag: services.posts.findPostsByTag,
+    searchPosts: services.posts.searchPosts,
+    postsCount: services.posts.postsCount,
   },
-
   Mutation: {
-    createPost: (_root, args) => {
-      return Posts.createPost(args)
-    },
-
-    updatePost: (_root, args) => {
-      return Posts.updatePost(args)
-    },
-
-    hidePost: (_root, args) => {
-      return Posts.hidePost(args)
-    },
-
-    deletePost: (_root, args) => {
-      return Posts.deletePost(args)
-    },
+    createPost: services.posts.createPost,
+    updatePost: services.posts.updatePost,
+    hidePost: services.posts.hidePost,
+    deletePost: services.posts.deletePost,
   },
 }

--- a/api/src/services/index.js
+++ b/api/src/services/index.js
@@ -1,0 +1,5 @@
+import { makeMergedServices } from '@hammerframework/api'
+
+import * as posts from './posts'
+
+export const services = makeMergedServices({ services: { posts } })

--- a/api/src/services/posts.js
+++ b/api/src/services/posts.js
@@ -13,75 +13,75 @@ const validate = (input) => {
   }
 }
 
-const Posts = {
-  allPosts: ({ page = 1, limit = 5, order = { postedAt: 'desc' } }) => {
-    const offset = (page - 1) * limit
+export const allPosts = ({
+  page = 1,
+  limit = 5,
+  order = { postedAt: 'desc' },
+}) => {
+  const offset = (page - 1) * limit
 
-    return photon.posts.findMany({
-      include: { tags: true },
-      first: limit,
-      skip: offset,
-      orderBy: order,
-    })
-  },
-
-  findPostById: ({ id }) => {
-    return photon.posts.findOne({
-      where: { id: parseInt(id) },
-      include: { tags: true },
-    })
-  },
-
-  findPostBySlug: ({ slug }) => {
-    return photon.posts.findOne({
-      where: { slug: slug },
-      include: { tags: true },
-    })
-  },
-
-  findPostsByTag: ({ tag }) => {
-    return photon.tags
-      .findOne({
-        where: { name: tag },
-      })
-      .posts({ include: { tags: true } })
-  },
-
-  searchPosts: ({ term }) => {
-    return photon.posts.findMany({
-      where: {
-        OR: [{ title: { contains: term } }, { body: { contains: term } }],
-      },
-      include: { tags: true },
-    })
-  },
-
-  postsCount: ({ page }) => {
-    return photon.posts.count()
-  },
-
-  createPost: ({ input }) => {
-    validate(input)
-    return photon.posts.create({ data: input })
-  },
-
-  updatePost: ({ id, input }) => {
-    validate(input)
-    return photon.posts.update({ data: input, where: { id: parseInt(id) } })
-  },
-
-  hidePost: ({ id }) => {
-    return photon.posts.update({
-      data: { postedAt: null },
-      where: { id: parseInt(id) },
-    })
-  },
-
-  deletePost: ({ id }) => {
-    return photon.posts.delete({
-      where: { id: parseInt(id) },
-    })
-  },
+  return photon.posts.findMany({
+    include: { tags: true },
+    first: limit,
+    skip: offset,
+    orderBy: order,
+  })
 }
 
-export default Posts
+export const findPostById = ({ id }) => {
+  return photon.posts.findOne({
+    where: { id: parseInt(id) },
+    include: { tags: true },
+  })
+}
+
+export const findPostBySlug = ({ slug }) => {
+  return photon.posts.findOne({
+    where: { slug: slug },
+    include: { tags: true },
+  })
+}
+
+export const findPostsByTag = ({ tag }) => {
+  return photon.tags
+    .findOne({
+      where: { name: tag },
+    })
+    .posts({ include: { tags: true } })
+}
+
+export const searchPosts = ({ term }) => {
+  return photon.posts.findMany({
+    where: {
+      OR: [{ title: { contains: term } }, { body: { contains: term } }],
+    },
+    include: { tags: true },
+  })
+}
+
+export const postsCount = ({ page }) => {
+  return photon.posts.count()
+}
+
+export const createPost = ({ input }) => {
+  validate(input)
+  return photon.posts.create({ data: input })
+}
+
+export const updatePost = ({ id, input }) => {
+  validate(input)
+  return photon.posts.update({ data: input, where: { id: parseInt(id) } })
+}
+
+export const hidePost = ({ id }) => {
+  return photon.posts.update({
+    data: { postedAt: null },
+    where: { id: parseInt(id) },
+  })
+}
+
+export const deletePost = ({ id }) => {
+  return photon.posts.delete({
+    where: { id: parseInt(id) },
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,10 +1044,10 @@
   resolved "https://registry.yarnpkg.com/@gouch/to-title-case/-/to-title-case-2.2.1.tgz#44a1de1bb02351d6a0d92ec1a325000158423874"
   integrity sha512-i/Hj91LfiE2pxYdIT0Ttdc/fIzdBwojDNQe6S6/N/Uf3xMmn0lWO+iLkAd84zs/NUGfTLsMUacDZzSy6N4jkcw==
 
-"@hammerframework/api@^0.0.1-alpha.13.2":
-  version "0.0.1-alpha.13.2"
-  resolved "https://registry.yarnpkg.com/@hammerframework/api/-/api-0.0.1-alpha.13.2.tgz#d0db6053cd45242cd2a31605c4d7e7d795b65784"
-  integrity sha512-KT+ucYAlQ8/lT2SvsaNoriwWB5zrN4fzWvgEV57uFgDBqW6DQSLMpoS8KTFUXI79FOvNnOd5f/J4qxxHaDLfMQ==
+"@hammerframework/api@^0.0.1-alpha.14":
+  version "0.0.1-alpha.14"
+  resolved "https://registry.yarnpkg.com/@hammerframework/api/-/api-0.0.1-alpha.14.tgz#0a108dc369d3636a466edeb5bcfc5bdc20f3cdf6"
+  integrity sha512-XQ+W+O77HL4CfKsX7w0dsxD3x0DgxMdYe9xHfsFuz2VzJVhbso3RhE/+ZIIM78iXAst3nImnwRl9dyrOZ7+y8w==
   dependencies:
     "@hammerframework/hammer-core" "^0.0.1-alpha.12.5"
     "@types/graphql-iso-date" "^3.3.3"
@@ -1057,6 +1057,7 @@
     graphql "^14.5.8"
     graphql-iso-date "^3.6.1"
     graphql-tools "4.0.6"
+    immer "^5.0.1"
     lodash.merge "^4.6.2"
 
 "@hammerframework/eslint-config-hammer@0.0.1-alpha.12":
@@ -6857,6 +6858,11 @@ image-size@^0.7.4:
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.7.5.tgz#269f357cf5797cb44683dfa99790e54c705ead04"
   integrity sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==
 
+immer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-5.0.1.tgz#1a1184fa758f68f1b5573db840825fb5164cceca"
+  integrity sha512-KFHV1ivrBmPCVRhjy9oBooypnPfJ876NTrWXMNoUhXFAaWWAViVqZ4l6HxPST52qcN82qqsR38/pCGYRWP5W7w==
+
 import-fresh@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
@@ -8692,13 +8698,6 @@ netlify@^2.4.8:
     through2-filter "^3.0.0"
     through2-map "^3.0.0"
     util.promisify "^1.0.0"
-
-nexus@v0.12.0-beta.14:
-  version "0.12.0-beta.14"
-  resolved "https://registry.yarnpkg.com/nexus/-/nexus-0.12.0-beta.14.tgz#541a0d41ce92cfa1a54d3199e9048fc92c3fc36a"
-  integrity sha512-jWHi+j9YhTwZZ0n82STJRNoU+HfrnrNGIw1sZs0c/9iscr1ewwpeQ7Lo+so0fIaboErAz47CHVcAn1BSr8kiLg==
-  dependencies:
-    tslib "^1.9.3"
 
 nice-try@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
I'm super excited to introduce the merged services object! ✨(The name needs work!)

## Creating a merged services object

```js
// src/services/index.js
import { makeMergedServices } from '@hammerframework/api'
import { Photon } from '@prisma/photon'

import * as posts from './posts'
import * as tags from './tags'

export const services = makeMergedServices({
    services: { posts, tags },
    context: {
        photon: new Photon(),
    },
    copyFromContextToArgs: ['currentUser'], // if this value is in the context it will be copied to the args. 
})

// The `services` object now contains: services.posts.<serviceFunctions> and `services.tags.<serviceFunctions>`

```

## A Service Function

You define you services as ordinary function exports in `src/services`.
```js
// src/services/posts.js

// beforeAction | afterAction are run between service functions if they're exported in the same file:
export const afterAction = (args, { serviceName, services, context: { currentUser } }) => {
  if (serviceName === 'posts.deletePost') {
    services.logger.log(`post ${id} delete by ${currentUser.login}`)
  }
}

export const deletePost = ({ id }) => {
  return photon.posts.delete({
    where: { id: parseInt(id) },
  })
}

/* ... */
```

Once you've merged a service they're ready to be used as GraphQL resolvers, `args` and `args.input` (mutation input patten) are flattened and made to be the service functions first argument so that they feel natural to use when not being executed by GraphQL, the second argument is an object that contains context and some meta information:

```js
{
    context: { 
        services, // the merged services object
        // context values from initialising the services, and context values from graphQL.
    }
    info, // information about the GraphQL request that ran this object.
    serviceName, // this current services path: e.g.: posts.deletePost
}
```

## Assigning services to GraphQL resolvers:

This step will go away once we automatically map resolvers to services.

```js
// src/graphql/posts.sdl.js

import { services } from 'src/services'

export const schema = gql`...`

export const resolvers = {
  Query: {
    allPosts: services.posts.allPosts,
    findPostById: services.posts.findPostById,
    findPostBySlug: services.posts.findPostBySlug,
    findPostsByTag: services.posts.findPostsByTag,
    searchPosts: services.posts.searchPosts,
    postsCount: services.posts.postsCount,
  },
  Mutation: {
    createPost: services.posts.createPost,
    updatePost: services.posts.updatePost,
    hidePost: services.posts.hidePost,
    deletePost: services.posts.deletePost,
  },
}
```