### PR TITLE
Fix install process for SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Install dependencies:
 
     yarn install
 
+Copy the `.env.example` file to a new file `.env`
+
+    cp .env.example .env
+
 Create a local SQLite database and seed it with a few blog posts:
 
     yarn redwood db up
@@ -80,7 +84,7 @@ To access the admin you have two options:
 
 #### Disabling Authentication
 
-Copy the `.env.example` file to a new file `.env` and edit it, setting the `USE_AUTHENTICATION` variable to `false` instead of `true`. Restart your `yarn dev`
+Set the `USE_AUTHENTICATION` variable in the `.env` file you created to `false` instead of `true`. Restart your `yarn dev`
 process and you should now be able to go to http://localhost:8910/admin without a login prompt.
 
 #### Enabling Identity on Netlify

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,5 +1,5 @@
 datasource hammerDatasource {
-  provider = "postgresql"
+  provider = "sqlite"
   url = env("DB_HOST")
 }
 


### PR DESCRIPTION
 * There was a value in `schema.prisma` that was set to use postgres which caused the database migrations to fail.  Switched it to sqlite.
 * Update README.md to tell users to copy `.env.example` to `.env` before running migrations since it holds values (`DB_HOST`) which are required for running migrations